### PR TITLE
Fix second image

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Let's get the code for the popular ReactJS framework.
 4.  Click the "Copy to clipboard" button (highlighted below). This will copy the
     URL for us to use when we clone.
 
-        ![Clone Repo Button](http://readme-pics.s3.amazonaws.com/clone-repo-clone-url-button.png)
+        ![Clone Repo Button](https://readme-pics.s3.amazonaws.com/clone-repo-clone-url-button.png)
 
 5.  In the terminal, run the `git clone` command. It takes the URL we just copied as an argument, like so:
 


### PR DESCRIPTION
Fixes #7 

- Remove extra tab inserted before image with latest merge
  - You have to double tab to nest the image underneath the list item so it translates as a part of that `<li>` when rendered in the browser (Example: See codeblock in my Flatiron blog post https://meghangutshall.com/2018/10/29/creating_beersnob/)
- Change 'http' to 'https' so as not to serve mixed content
  - Reference: [Resolving problems with mixed content](https://help.github.com/en/github/working-with-github-pages/securing-your-github-pages-site-with-https#resolving-problems-with-mixed-content)